### PR TITLE
Restrict GH workflow perms to read-only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   - pull_request
   - push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build SkillMMO


### PR DESCRIPTION
Explicitly sets default workflow permissions to read-only
